### PR TITLE
User stdout and stderr respectively instead of console

### DIFF
--- a/bin/depsane.js
+++ b/bin/depsane.js
@@ -4,8 +4,11 @@
 const minimist = require("minimist");
 const main = require("../");
 
+const output = {
+  log: (str) => process.stdout.write(`${str}\n`),
+  error: (str) => process.stderr.write(`${str}\n`),
+};
+
 (async () => {
-  const retCode = await main(minimist(process.argv.slice(2)));
-  // eslint-disable-next-line node/no-process-exit
-  process.exit(retCode);
+  process.exitCode = await main(minimist(process.argv.slice(2)), output);
 })();

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const micromatch = require("micromatch");
 
 const { analyze } = require("./lib/analyze");
 
-async function main(argv, output = console) {
+async function main(argv, output) {
   let retCode = 0;
   try {
     const root = argv._[0] || ".";
@@ -29,10 +29,8 @@ async function main(argv, output = console) {
     );
 
     if (unusedDependencies.length > 0) {
-      // eslint-disable-next-line no-console
       output.log("Unused dependencies");
       for (const dep of unusedDependencies) {
-        // eslint-disable-next-line no-console
         output.log(`* ${dep}`);
       }
       retCode = 1;
@@ -43,10 +41,8 @@ async function main(argv, output = console) {
     );
 
     if (unusedDevDependencies.length > 0) {
-      // eslint-disable-next-line no-console
       output.log("Unused devDependencies");
       for (const dep of unusedDevDependencies) {
-        // eslint-disable-next-line no-console
         output.log(`* ${dep}`);
       }
       retCode = 1;
@@ -57,7 +53,6 @@ async function main(argv, output = console) {
     );
 
     if (missingDependencies.length > 0) {
-      // eslint-disable-next-line no-console
       output.log("Missing dependencies");
       for (const dep of missingDependencies) {
         const referencedFrom = usedDependencies[dep];
@@ -65,12 +60,10 @@ async function main(argv, output = console) {
           .map((ref) => `"${path.relative(root, ref)}"`)
           .join(", ");
         if (devDependencies[dep]) {
-          // eslint-disable-next-line no-console
           output.log(
             `* ${dep}: ${x} (exists in devDependencies but needed in dependencies!)`
           );
         } else {
-          // eslint-disable-next-line no-console
           output.log(`* ${dep}: ${x}`);
         }
       }
@@ -82,7 +75,6 @@ async function main(argv, output = console) {
     );
 
     if (missingDevDependencies.length > 0) {
-      // eslint-disable-next-line no-console
       output.log("Missing devDependencies");
       for (const dep of missingDevDependencies) {
         const referencedFrom = usedDevDependencies[dep];
@@ -90,12 +82,10 @@ async function main(argv, output = console) {
           .map((ref) => `"${path.relative(root, ref)}"`)
           .join(", ");
         if (dependencies[dep]) {
-          // eslint-disable-next-line no-console
           output.log(
             `* ${dep}: ${x} (exists in dependencies but is only used as dev, maybe move it to devDependencies?)`
           );
         } else {
-          // eslint-disable-next-line no-console
           output.log(`* ${dep}: ${x}`);
         }
       }

--- a/lib/analyze.js
+++ b/lib/analyze.js
@@ -39,7 +39,7 @@ async function analyze(root, ignoreDirs = [], output) {
 
   // Check files along the main path, i.e. deps!
   const { missingDependencies, unusedDependencies, usedDependencies } =
-    await analyzeMain(root, entryPoints, dependencies, alreadyAnalyzed);
+    await analyzeMain(root, entryPoints, dependencies, alreadyAnalyzed, output);
 
   // Check other files
   const { missingDevDependencies, unusedDevDependencies, usedDevDependencies } =
@@ -49,7 +49,8 @@ async function analyze(root, ignoreDirs = [], output) {
       dependencies,
       alreadyAnalyzed,
       ignoreDirs,
-      packageInfo.scripts || {}
+      packageInfo.scripts || {},
+      output
     );
 
   const finalMissingDevDependencies = missingDevDependencies.filter(
@@ -68,7 +69,7 @@ async function analyze(root, ignoreDirs = [], output) {
   };
 }
 
-async function analyzeMain(root, entryPoints, dependencies, alreadyAnalyzed) {
+async function analyzeMain(root, entryPoints, dependencies, alreadyAnalyzed, output) {
   const follows = [];
   const usedDependencies = {};
   follows.push(
@@ -76,7 +77,7 @@ async function analyzeMain(root, entryPoints, dependencies, alreadyAnalyzed) {
   );
   while (follows.length > 0) {
     const filename = follows.pop();
-    const { deps, locals } = await analyzeFile(filename, alreadyAnalyzed);
+    const { deps, locals } = await analyzeFile(filename, alreadyAnalyzed, output);
     for (const dep of deps) {
       const globalDep = usedDependencies[dep.mod] || new Set();
       globalDep.add(dep.file);
@@ -108,12 +109,13 @@ async function analyzeOther(
   dependencies,
   alreadyAnalyzed,
   ignoreDirs,
-  scripts
+  scripts,
+  output
 ) {
   const usedDevDependencies = {};
 
   // analyze scripts
-  await guessDevBins(root, scripts, usedDevDependencies);
+  await guessDevBins(root, scripts, usedDevDependencies, output);
 
   // analyze js files
   const entryInfos = await readdirp.promise(root, {
@@ -160,7 +162,7 @@ async function fileExists(p) {
     .catch(() => false);
 }
 
-async function analyzeFile(maybeFilename, alreadyAnalyzed) {
+async function analyzeFile(maybeFilename, alreadyAnalyzed, output) {
   let filename;
   if (maybeFilename.endsWith(".json")) {
     return { locals: [], deps: [] };
@@ -179,8 +181,7 @@ async function analyzeFile(maybeFilename, alreadyAnalyzed) {
     }
   }
   if (!filename) {
-    // eslint-disable-next-line no-console
-    console.error(`${maybeFilename} does not exist`);
+    output.error(`${maybeFilename} does not exist`);
     return { locals: [], deps: [] };
   }
 
@@ -228,8 +229,7 @@ async function analyzeFile(maybeFilename, alreadyAnalyzed) {
       },
     });
   } catch (err) {
-    // eslint-disable-next-line no-console
-    console.error(`got error ${err.message} when parsing ${maybeFilename}`);
+    output.error(`got error ${err.message} when parsing ${maybeFilename}`);
   }
   return { deps, locals };
 }
@@ -252,7 +252,7 @@ function requireCall(node) {
   return null;
 }
 
-async function guessDevBins(root, scripts, usedDevDependencies) {
+async function guessDevBins(root, scripts, usedDevDependencies, output) {
   const targets = Object.keys(scripts).filter((x) => x !== "start"); // start is a special target, it is not dev
   const guessedBins = [];
   for (const target of targets) {
@@ -289,8 +289,7 @@ async function guessDevBins(root, scripts, usedDevDependencies) {
           usedDevDependencies[actualExt] = globalExtDep;
         }
       } catch (e) {
-        // eslint-disable-next-line no-console
-        console.error(`Could not find eslint config ${path.join(root, ".eslintrc.json")}`);
+        output.error(`Could not find eslint config ${path.join(root, ".eslintrc.json")}`);
       }
     } else if (bin === "mocha") {
       try {
@@ -301,8 +300,7 @@ async function guessDevBins(root, scripts, usedDevDependencies) {
           usedDevDependencies[ext] = globalExtDep;
         }
       } catch (e) {
-      // eslint-disable-next-line no-console
-        console.error("Could not find mocha config");
+        output.error("Could not find mocha config");
       }
     }
   }


### PR DESCRIPTION
– Default the output object to use std{out,err} directly
– Set exit code instead of calling process.exit()
– This also removes all eslint-disables
